### PR TITLE
ci: add Elixir 1.19 support and enable warnings as errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ jobs:
             otp: "26.2"
           - elixir: "1.18.4"
             otp: "27.3.4"
+          - elixir: "1.19.5"
+            otp: "27.3.4"
     env:
       MIX_ENV: test
     steps:

--- a/lib/req_trino.ex
+++ b/lib/req_trino.ex
@@ -104,7 +104,7 @@ defmodule ReqTrino do
 
       %{"nextUri" => next_uri, "stats" => %{"state" => "RUNNING"}} ->
         new_request =
-          Req.new(url: URI.parse(next_uri))
+          Req.new(url: URI.new!(next_uri))
           |> build_req_params(request_options)
 
         %Req.Response{status: 200, body: body} = Req.get!(new_request)
@@ -127,7 +127,7 @@ defmodule ReqTrino do
         }
 
       %{"nextUri" => next_uri, "stats" => %{"state" => _}} ->
-        new_request = %{request | url: URI.parse(next_uri), method: :get}
+        new_request = %{request | url: URI.new!(next_uri), method: :get}
 
         Request.halt(request, Req.get!(new_request))
 

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule ReqTrino.MixProject do
       version: @version,
       description: @description,
       name: "ReqTrino",
-      elixir: "~> 1.14",
+      elixir: "~> 1.17",
       preferred_cli_env: [
         "test.all": :test,
         docs: :docs,
@@ -21,7 +21,7 @@ defmodule ReqTrino.MixProject do
       deps: deps(),
       aliases: aliases(),
       package: package(),
-      elixirc_options: [warnings_as_errors: false]
+      elixirc_options: [warnings_as_errors: true]
     ]
   end
 


### PR DESCRIPTION
- Add Elixir 1.19.0/OTP 27.3.4 to CI matrix
- Replace deprecated URI.parse/1 with URI.new!/1
- Bump minimum Elixir requirement to ~> 1.17
- Re-enable warnings_as_errors